### PR TITLE
Link R to OpenBLAS for fast and multithreaded linear algebra

### DIFF
--- a/Singularity
+++ b/Singularity
@@ -21,7 +21,7 @@ From: ubuntu:16.04
   # Get dependencies
   apt-get update
   apt-get install -y --no-install-recommends \
-    locales
+    locales libopenblas-dev
 
   # Configure default locale
   echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen

--- a/Singularity.3.6.2
+++ b/Singularity.3.6.2
@@ -21,7 +21,7 @@ From: ubuntu:16.04
   # Get dependencies
   apt-get update
   apt-get install -y --no-install-recommends \
-    locales
+    locales libopenblas-dev
 
   # Configure default locale
   echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen


### PR DESCRIPTION
The OpenBLAS libraries are more optimized than the default
R BLAS. Moreover, they offer multithreaded matrix operations
without any R code change. For this set either of the
environment variables OPENBLAS_NUM_THREADS, GOTO_NUM_THREADS
or OMP_NUM_THREADS to the desired thread number (the environment
variables are listed in decreasing priority). Alternatively,
use packages like wrathematics/openblasctl (on GitHub)